### PR TITLE
Increased precision of electricity cost

### DIFF
--- a/octoprint_costestimation/templates/costestimation_settings.jinja2
+++ b/octoprint_costestimation/templates/costestimation_settings.jinja2
@@ -79,7 +79,7 @@
         <label class="control-label">{{ _('Electricity cost') }}</label>
         <div class="controls">
             <div class="input-append">
-                <input type="number" step="0.01" min="0" class="input-mini text-right"data-bind="value: $root.settings.settings.plugins.costestimation.costOfElectricity">
+                <input type="number" step="0.001" min="0" class="input-mini text-right"data-bind="value: $root.settings.settings.plugins.costestimation.costOfElectricity">
                 <span class="add-on"><span data-bind="text: $root.settings.settings.plugins.costestimation.currency"></span>/kWh</span>
             </div>
         </div>


### PR DESCRIPTION
Electricity costs, for me, are calculated in 3 digits of cents here in germany. Thus, I changed the input box of the plugin to accomodate this precision.

TBH, I don't know anything about octoprint-plugins, so I hope this pull request is somewhere near correct. It works on my octoprint installation.

Oh and...merry christmas :)