### PR TITLE
adds python 3.7 compatibility

### DIFF
--- a/octoprint_costestimation/__init__.py
+++ b/octoprint_costestimation/__init__.py
@@ -89,6 +89,7 @@ class CostEstimationPlugin(octoprint.plugin.SettingsPlugin,
 
 
 __plugin_name__ = "Cost Estimation"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 
 def __plugin_load__():


### PR DESCRIPTION
I upgraded to Python 3.7 and I could not run your plug-in.

I got the following error: "Plugin Cost Estimation (2.1.3) is not compatible to Python 3.7.3 (compatibility string: >=2.7,<3)."

So I just added the __plugin_pythoncompat__ information and run this plugin. Now it works like a charm with Python 3.7.3 and I had no issue with my OctoPrint setup.
